### PR TITLE
Fix missing dependency on `six`

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -4,8 +4,11 @@
 [metadata]
 groups = ["default", "dev"]
 strategy = ["cross_platform", "inherit_metadata"]
-lock_version = "4.4.1"
-content_hash = "sha256:97a94c4ff20857f33f6110f0695d53493d789841dd0612383a8190e5dd1229f6"
+lock_version = "4.5.0"
+content_hash = "sha256:47baf19c63f3fabb7829bd1dd936c7729a4df5d49165eea85ee189592511ee27"
+
+[[metadata.targets]]
+requires_python = ">=3.8"
 
 [[package]]
 name = "databind"
@@ -150,6 +153,17 @@ marker = "python_version < \"3.10\""
 files = [
     {file = "setuptools-70.0.0-py3-none-any.whl", hash = "sha256:54faa7f2e8d2d11bcd2c07bed282eef1046b5c080d1c32add737d7b5817b1ad4"},
     {file = "setuptools-70.0.0.tar.gz", hash = "sha256:f211a66637b8fa059bb28183da127d4e86396c991a942b028c6650d4319c3fd0"},
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+summary = "Python 2 and 3 compatibility utilities"
+groups = ["default"]
+files = [
+    {file = "six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"},
+    {file = "six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ authors = [
 ]
 dependencies = [
     "databind>=4.5.2",
+    "six>=1.17.0",
 ]
 requires-python = ">=3.8"
 readme = "README.md"


### PR DESCRIPTION
This simply adds `six` as a dependency to the pyproject.

Resolves #4 